### PR TITLE
Edited PR #169

### DIFF
--- a/doc/ordinal.md
+++ b/doc/ordinal.md
@@ -142,7 +142,7 @@ woltka tools collapse -i pathway.biom  -m pathway-to-super.map    -o super.biom
 
 In the [WoL data release](wol.md), there are pre-built mappings to UniRef, GO, MetaCyc, KEGG and more.
 
-For some databases, such as [MetaCyc](https://metacyc.org), you might encounter an error regarding `AssertionError: Conflicting values found for ...`, in this case we recommend generating the gene-level profile with `woltka classify`, and then collapsing to individual levels one at a time with `woltka tools collapse`.
+- Note: For some databases, such as [MetaCyc](https://metacyc.org), you might encounter an error regarding `AssertionError: Conflicting values found for ...`. This is likely because some classification units were simultaneously assigned to multiple ranks in the database, which causes conflicts in the Woltka workflow. In this case we recommend generating the gene-level profile with `woltka classify`, and then collapsing to individual levels one at a time with `woltka tools collapse`.
 
 ## Pathway coverage
 

--- a/woltka/table.py
+++ b/woltka/table.py
@@ -455,9 +455,9 @@ def round_table(table, digits=None):
 
     # remove empty rows
     for i in reversed(todel):
-        del(table[0][i])
-        del(table[1][i])
-        del(table[3][i])
+        del table[0][i]
+        del table[1][i]
+        del table[3][i]
 
 
 def filter_table(table, th):

--- a/woltka/tests/test_biom.py
+++ b/woltka/tests/test_biom.py
@@ -114,7 +114,7 @@ class BiomTests(TestCase):
             'S2': {'G1': 3, 'G2': 4, 'G3': 4},
             'S3': {'G1': 2, 'G2': 3, 'G3': 0}})))
         self.assertEqual(obs.descriptive_equality(exp), 'Tables appear equal')
-        del(sizes['G3'])
+        del sizes['G3']
         with self.assertRaises(KeyError):
             divide_biom(obs, sizes)
 

--- a/woltka/tests/test_classify.py
+++ b/woltka/tests/test_classify.py
@@ -133,7 +133,7 @@ class ClassifyTests(TestCase):
                'Cdiff': 3.0,
                'Strep': 4.5}
         self.assertDictEqual(dict(obs), exp)
-        del(sizes['G3'])
+        del sizes['G3']
         with self.assertRaises(KeyError):
             counter_size(subque, taxque, sizes)
 
@@ -204,7 +204,7 @@ class ClassifyTests(TestCase):
                ('Cdiff', 'ligase'):     4.5,
                ('Strep', 'ligase'):     6.5}
         self.assertDictEqual(dict(obs), exp)
-        del(sizes['G3'])
+        del sizes['G3']
         with self.assertRaises(KeyError):
             counter_size(subque, taxque, sizes)
 

--- a/woltka/tests/test_table.py
+++ b/woltka/tests/test_table.py
@@ -454,7 +454,7 @@ class TableTests(TestCase):
         self.assertEqual(ob2.descriptive_equality(ex2), 'Tables appear equal')
 
         # missing size
-        del(sizes['G3'])
+        del sizes['G3']
         with self.assertRaises(KeyError):
             divide_table(obs, sizes)
 

--- a/woltka/tests/test_workflow.py
+++ b/woltka/tests/test_workflow.py
@@ -577,7 +577,7 @@ class WorkflowTests(TestCase):
         self.assertDictEqual(data['ko']['S1'], {'T1': 0.95, 'T2': 0.5})
 
         # missing size
-        del(sizes['G3'])
+        del sizes['G3']
         with self.assertRaises(ValueError) as ctx:
             assign_readmap(qryq, subq, {'ko': {}}, 'ko', 'S1', assigners,
                            tree=tree, rankdic=rankdic, sizes=sizes)


### PR DESCRIPTION
Hello @ElDeveloper Thank you for editing the documentation! I made minor edits. I found that the pycodestyle has been updated such that code like `del(d['a'])` now violates the rule, so I had to update those codes as well.